### PR TITLE
all deployments to s3 are under stac/ path for cloudfront path routing

### DIFF
--- a/.github/workflows/push-to-aws-s3.yaml
+++ b/.github/workflows/push-to-aws-s3.yaml
@@ -44,7 +44,7 @@ jobs:
           npm install crypto-browserify
           npm install stream-browserify
           npm install browserify-zlib
-          export APP_PUBLIC_PATH=/$IMAGE_TAG
+          export APP_PUBLIC_PATH=/stac/$IMAGE_TAG
           npm run build
 
       - name: Setup AWS CLI
@@ -57,4 +57,4 @@ jobs:
       - name: Sync files to S3 bucket
         run: |
           echo ls
-          aws s3 cp dist s3://resource-catalog-browser/$IMAGE_TAG --recursive
+          aws s3 cp dist s3://resource-catalog-browser/stac/$IMAGE_TAG --recursive


### PR DESCRIPTION
To deploy behind CloudFront and take advantage of caching we need a common path to set as cache path pattern. ClooudFront does not easily support path rewrites, so it was easiest to deploy all s3 objects underneath a common root directory. "/stac" was chosen.