### PR TITLE
Must not share package names/locations across different packages.

### DIFF
--- a/.github/workflows/push-to-aws-s3.yaml
+++ b/.github/workflows/push-to-aws-s3.yaml
@@ -57,4 +57,4 @@ jobs:
       - name: Sync files to S3 bucket
         run: |
           echo ls
-          aws s3 cp dist s3://eodhp-static-web-artefacts/static-apps/resource-catalogue/$IMAGE_TAG --recursive
+          aws s3 cp dist s3://eodhp-static-web-artefacts/static-apps/stac-browser/$IMAGE_TAG --recursive


### PR DESCRIPTION
The new resource catalogue UI was set up to write build packages with the same name as STAC Browser ('resource-catalogue'), resulting in them overwriting each other in the web app package repo. This will cause enormous confusion and potentially downtime. It also makes it impossible to serve STAC Browser from EODH.

To avoid this, this changes the name of the STAC Browser packages to 'stac-browser'.
